### PR TITLE
Added Dockerfile to run MySQL in a Docker container.

### DIFF
--- a/Mysql_Dockerfile/Database_Student.sql
+++ b/Mysql_Dockerfile/Database_Student.sql
@@ -1,0 +1,21 @@
+-- This line creates a new database named "student"
+CREATE DATABASE student;
+
+-- This line specifies that any subsequent SQL statements should be executed in the "student" database
+use student;
+
+-- This line creates a new table named "students" with three columns: "StudentID", "FirstName", and "SurName"
+-- The "StudentID" column is an auto-incrementing integer and the primary key of the table
+-- The "FirstName" and "SurName" columns are required (NOT NULL) and have a maximum length of 100 characters
+CREATE TABLE students(
+    StudentID INT NOT NULL AUTO_INCREMENT,
+    FirstName VARCHAR(100) NOT NULL,
+    SurName VARCHAR(100) NOT NULL,
+    PRIMARY KEY (StudentID)
+);
+
+-- This line inserts two new rows into the "students" table
+-- The first row has a "FirstName" value of "Tirdad" and a "SurName" value of "Koraei"
+-- The second row has a "FirstName" value of "Emma" and a "SurName" value of "Smith"
+INSERT INTO students(FirstName, SurName)
+VALUES("Tirdad", "Koraei"), ("Emma", "Smith");

--- a/Mysql_Dockerfile/Dockerfile
+++ b/Mysql_Dockerfile/Dockerfile
@@ -1,0 +1,6 @@
+FROM mysql:latest
+
+ENV MYSQL_ROOT_PASSWORD=password
+ENV MYSQL_DATABASE=mydb
+
+COPY ./Database_Student.sql /docker-entrypoint-initdb.d/

--- a/Mysql_Dockerfile/README.md
+++ b/Mysql_Dockerfile/README.md
@@ -1,0 +1,27 @@
+# MySQL Dockerfile
+
+This project provides a Dockerfile to run MySQL in a Docker container.
+
+## Prerequisites
+
+-   Docker installed
+
+# Build the Docker Image
+
+To build the Docker image, navigate to the directory where the **'Dockerfile'** is located and run the following command:
+
+        sudo docker build -t msql_db .
+
+## Run the Docker Container
+
+To run the Docker container, execute the following command:
+
+        sudo docker run -d -p 3306:3306 msql_db
+
+## Database and Table Creation
+
+The **'Database_Student.sql'** file included in this project contains SQL statements to create a new database named "student" and a new table named "students" with three columns: "StudentID", "FirstName", and "SurName". The file also includes statements to insert two new rows into the "students" table.
+
+These SQL statements are executed when the Docker container is started, thanks to the **'COPY'** command in the **'Dockerfile'** that copies the Database_Student.sql file to the **'/docker-entrypoint-initdb.d/'** directory inside the container.
+
+To connect to the database and query the data, use a MySQL client such as **'mysql'** and connect to **'localhost:3306'** with the username **'root'** and password **'password'**.


### PR DESCRIPTION
This pull request adds a Dockerfile and an SQL script for creating a MySQL database with a table and some sample data.

The Dockerfile uses the official MySQL image as a base and sets some environment variables for the database password and name. It also copies the SQL script to the Docker container's entrypoint directory so that it can be automatically executed when the container is started.

The SQL script creates a new database named "student" and a table named "students" with three columns: "StudentID", "FirstName", and "SurName". It then inserts two rows into the "students" table as sample data.

This pull request should make it easy for developers to spin up a MySQL database with sample data in a Docker container for testing and development purposes.

Please review and let me know if there are any concerns or feedback. 
Thanks!