### PR TITLE
Compress RUN in Dockerfile to Reduce Image Size

### DIFF
--- a/Compress_RUN_Dockerfile_Reduce/Dockerfile
+++ b/Compress_RUN_Dockerfile_Reduce/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y nano net-tools dnsutils && \
+    rm -rf /var/lib/apt/lists/*

--- a/Compress_RUN_Dockerfile_Reduce/README.md
+++ b/Compress_RUN_Dockerfile_Reduce/README.md
@@ -1,0 +1,23 @@
+# Compress RUN in Dockerfile to Reduce Image Size
+
+This Dockerfile builds an image based on Ubuntu 22.04 and installs some basic networking utilities (**'nano'**, **'net-tools'**, and **'dnsutils'**). The Dockerfile is optimized to minimize the size of the final image by compressing the **'RUN'** instructions and removing unnecessary files.
+
+
+## Building the Image
+
+To build the image, navigate to the directory containing the Dockerfile and run the following command:
+
+
+        docker build -t my-ubuntu-image .
+
+This will build the image with the tag **'my-ubuntu-image'**. You can choose any tag name you like.
+
+## Running the Container
+
+To run a container based on the image, use the following command:
+
+        docker run -it my-ubuntu-image
+
+This will start a new container and drop you into a shell prompt inside the container. From here, you can use the installed networking utilities like **'nano'**, **'ifconfig'**, **'ping'**, etc.
+
+Feel free to modify and use it as needed for your own projects.


### PR DESCRIPTION
## Description

This pull request updates the Dockerfile to optimize it for image size by compressing the **'RUN'** instructions and removing unnecessary files. It also updates the package list to the latest version.

## Changes Made

-    Compressed the **'RUN'** instructions into a single command using the **'&&'** operator.
-    Removed unnecessary files to reduce image size.
-    Updated the package list to the latest version.
-    The README file has been updated to reflect the changes made in this pull request.


Please let me know if there are any further changes or improvements that need to be made. 

Thank you!